### PR TITLE
merge recent changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "onelogin/php-saml": "^2.11"
+        "onelogin/php-saml": "^3.3"
     },
     "autoload": {
         "psr-4": {

--- a/lib/AutoPoA.php
+++ b/lib/AutoPoA.php
@@ -21,15 +21,15 @@
 
 namespace RedIRIS\SamlPoA;
 
-use \OneLogin_Saml2_Auth;
+use \OneLogin\Saml2\Auth;
 
 class AutoPoA extends PoA
 {
     /**
-     * @param \OneLogin_Saml2_Auth $auth
+     * @param \OneLogin\Saml2\Auth $auth
      * @param Array $settings
      */
-    public function __construct(\OneLogin_Saml2_Auth $auth, Array $settings)
+    public function __construct(\OneLogin\Saml2\Auth $auth, Array $settings)
     {
         parent::__construct($auth, $settings);
 

--- a/lib/Builder.php
+++ b/lib/Builder.php
@@ -24,7 +24,7 @@ class Builder
 {
     public static function poa(Array $settings)
     {
-        $auth = new \OneLogin_Saml2_Auth($settings);
+        $auth = new \OneLogin\Saml2|Auth($settings);
 
         return new PoA(
             $auth,
@@ -34,7 +34,7 @@ class Builder
 
     public static function autopoa(Array $settings)
     {
-        $auth = new \OneLogin_Saml2_Auth($settings);
+        $auth = new \OneLogin\Saml2\Auth($settings);
 
         return new AutoPoA(
             $auth,

--- a/lib/Builder.php
+++ b/lib/Builder.php
@@ -24,7 +24,7 @@ class Builder
 {
     public static function poa(Array $settings)
     {
-        $auth = new \OneLogin\Saml2|Auth($settings);
+        $auth = new \OneLogin\Saml2\Auth($settings);
 
         return new PoA(
             $auth,

--- a/lib/PoA.php
+++ b/lib/PoA.php
@@ -151,7 +151,7 @@ class PoA
             ];
 
             if (isset($_POST['RelayState'])
-                && \OneLogin_Saml2_Utils::getSelfURL() != $_POST['RelayState']) {
+                && \OneLogin\Saml2\Utils::getSelfURL() != $_POST['RelayState']) {
                 $this->auth->redirectTo($_POST['RelayState']);
             }
 
@@ -274,7 +274,7 @@ class PoA
 
         // Just remove local session information
         if ($slo === false) {
-            \OneLogin_Saml2_Utils::deleteLocalSession();
+            \OneLogin\Saml2\Utils::deleteLocalSession();
             return true;
         }
 

--- a/lib/PoA.php
+++ b/lib/PoA.php
@@ -20,24 +20,24 @@
 
 namespace RedIRIS\SamlPoA;
 
-use \OneLogin_Saml2_Auth;
+use \OneLogin\Saml2\Auth;
 
 class PoA
 {
     /** @var Array */
     protected $settings;
 
-    /** @var \OneLogin_Saml2_Auth */
+    /** @var \OneLogin\Saml2\Auth */
     protected $auth;
 
     /** @var RedIRIS\SamlPoA\Authz\AuthorizationEngine[] */
     protected $authz_engines;
 
     /**
-     * @param \OneLogin_Saml2_Auth $auth
+     * @param \OneLogin\Saml2\Auth $auth
      * @param Array $settings
      */
-    public function __construct(\OneLogin_Saml2_Auth $auth, Array $settings)
+    public function __construct(\OneLogin\Saml2\Auth $auth, Array $settings)
     {
         $this->auth = $auth;
         $this->settings = $settings;


### PR DESCRIPTION
- `onelogin/php-saml` dependency updated to ^3.3, with this version `php-mcrypt` is no longer necessary
- `onelogin/php-saml`  calls updated to use namespaces
